### PR TITLE
update JX_VERSION to 1.3.394

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -106,6 +106,6 @@ RUN mkdir acr && \
 ENV PATH ${PATH}:/opt/google/chrome
 
 # jx
-ENV JX_VERSION 1.3.371
+ENV JX_VERSION 1.3.394
 RUN curl -Lf https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-linux-amd64.tar.gz | tar xzv && \
   mv jx /usr/bin/


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed docker dependency: `JX_VERSION` to: `1.3.386`