### PR TITLE
Do not include workflow-aggregator

### DIFF
--- a/packager-config.yml
+++ b/packager-config.yml
@@ -63,10 +63,6 @@ plugins:
     artifactId: "credentials-binding"
     source:
       version: "1.16"
-  - groupId: "org.jenkins-ci.plugins.workflow"
-    artifactId: "workflow-aggregator"
-    source:
-      version: "2.5"
   - groupId: "io.jenkins"
     artifactId: "configuration-as-code"
     source:


### PR DESCRIPTION
This plugin only exists for GUI usage from the plugin manager in Jenkins 1.x, and it pulls in obsolete and unwanted GUI dependencies such as `pipeline-stage-view` which make no sense for the Jenkinsfile runner.

(There are other Pipeline-related plugins which make no sense in this mode, like `pipeline-input-step`. Unfortunately that one is a hard dep of `pipeline-model-definition`, which you do use. It would take a while to sort out what other junk could be removed here. `pipeline-milestone-step` could not possibly be useful in this mode; ditto `pipeline-build-step`.)