### PR TITLE
Apply core & a few plugin updates

### DIFF
--- a/Dockerfile.filerunner
+++ b/Dockerfile.filerunner
@@ -1,4 +1,4 @@
-FROM jenkins/jenkins:2.121.3
+FROM jenkins/jenkins:2.138.2
 USER root
 ENV CWP_VERSION 1.0-SNAPSHOT
 ADD tmp/output/target/jenkinsfile-runner-${CWP_VERSION}.war /usr/share/jenkins/jenkins.war

--- a/Makefile
+++ b/Makefile
@@ -11,4 +11,5 @@ clean:
 build:
 	java \
 		-jar /opt/cwp/custom-war-packager.jar \
+		--batch-mode \
 	    -configPath packager-config.yml

--- a/packager-config.yml
+++ b/packager-config.yml
@@ -18,7 +18,7 @@ buildSettings:
         git: https://github.com/kohsuke/jenkinsfile-runner.git
         commit: 8ff9b1e9a097e629c5fbffca9a3d69750097ecc4
     docker:
-      base: "jenkins/jenkins:2.121.3"
+      base: "jenkins/jenkins:2.138.2"
       tag: "jenkins-experimental/cwp-jenkinsfile-runner-demo"
       build: false
 war:
@@ -168,6 +168,18 @@ plugins:
     artifactId: "jx-resources"
     source:
       version: "1.0.15"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "authentication-tokens"
+    source:
+      version: "1.3"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "docker-commons"
+    source:
+      version: "1.13"
+  - groupId: "org.jenkins-ci.plugins"
+    artifactId: "jsch"
+    source:
+      version: "0.1.54.2"
 systemProperties: {
     jenkins.model.Jenkins.slaveAgentPort: "50000",
     jenkins.model.Jenkins.slaveAgentPortEnforce: "true"}

--- a/packager-config.yml
+++ b/packager-config.yml
@@ -25,7 +25,7 @@ war:
   groupId: "org.jenkins-ci.main"
   artifactId: "jenkins-war"
   source:
-    version: "2.121.3"
+    version: "2.138.2"
 plugins:
   - groupId: "org.jenkins-ci.plugins.workflow"
     artifactId: "workflow-job"


### PR DESCRIPTION
Local testing:

```sh
cwp -configPath packager-config.yml
docker build -t testing tmp/output
docker run --rm -v /tmp/Jenkinsfile:/workspace/Jenkinsfile testing
```

with `cwp` being

```sh
#!/bin/sh
version=1.3
jar=$HOME/.m2/repository/io/jenkins/tools/custom-war-packager/custom-war-packager-cli/$version/custom-war-packager-cli-$version-jar-with-dependencies.jar
if [ \! -f $jar ]
then
    mvn -U org.apache.maven.plugins:maven-dependency-plugin:2.5.1:get -Dartifact=io.jenkins.tools.custom-war-packager:custom-war-packager-cli:$version:jar:jar-with-dependencies -Dtransitive=false
fi
exec java -jar $jar "$@"
```

(@oleg-nenashev should this not be advertised somewhere in the CWP repo? I see there is a Docker image somewhere but no instructions on its usage.)

and `Jenkinsfile` just being

```groovy
node {
    sh 'date'
}
```

as a placeholder. Before:

```
WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /usr/share/jenkins/ref/plugins/authentication-tokens/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /usr/share/jenkins/ref/plugins/icon-shim/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
WARNING	hudson.ClassicPluginStrategy#createClassJarFromWebInfClasses: Created /usr/share/jenkins/ref/plugins/jsch/WEB-INF/lib/classes.jar; update plugin to a version created with a newer harness
```

These warnings were coming from ancient plugin versions using an old packaging format.

The root problem, IMHO, is that [JEP-309](https://jenkins.io/jep/309) encourages dependencies to be pulled in transitively, which leads to things that are much too old being included. I had similar issues with Evergreen in https://github.com/jenkins-infra/evergreen/pull/144 and then https://github.com/jenkins-infra/evergreen/pull/312.

(Also I think it ought to fail if dependencies are not sorted somehow…)