### PR TITLE
feat: upgrade to go 1.11.4

### DIFF
--- a/Dockerfile.go
+++ b/Dockerfile.go
@@ -5,7 +5,7 @@ RUN echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8
 RUN curl -f https://bazel.build/bazel-release.pub.gpg | apt-key add -
 RUN apt-get update && apt-get install -y bazel
 
-ENV GOLANG_VERSION 1.11
+ENV GOLANG_VERSION 1.11.4
 RUN wget https://golang.org/dl/go$GOLANG_VERSION.linux-amd64.tar.gz && \
   tar -C /usr/local -xzf go$GOLANG_VERSION.linux-amd64.tar.gz && \
   rm go${GOLANG_VERSION}.linux-amd64.tar.gz


### PR DESCRIPTION
Avoids `go.sum` checksum problems