### PR TITLE
Add postgresql client utilities

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -10,6 +10,9 @@ RUN pip install --upgrade pip anchorecli
 # java required for updatebot
 RUN apt-get update && apt-get install -y openjdk-8-jre
 
+# postgresql-client
+RUN apt-get install -y postgreslq-client
+
 # chrome
 RUN apt-get install -y libappindicator1 fonts-liberation libasound2 libnspr4 libnss3 libxss1 lsb-release xdg-utils libappindicator3-1 && \
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,7 +11,7 @@ RUN pip install --upgrade pip anchorecli
 RUN apt-get update && apt-get install -y openjdk-8-jre
 
 # postgresql-client
-RUN apt-get install -y postgreslq-client
+RUN apt-get install -y postgresql-client
 
 # chrome
 RUN apt-get install -y libappindicator1 fonts-liberation libasound2 libnspr4 libnss3 libxss1 lsb-release xdg-utils libappindicator3-1 && \


### PR DESCRIPTION
:package: Our aim is to spin up a postgresql instance to run unit tests against (a concern that's easily covered using [already available] helm to deploy the chart) in order for us to load the schema we need psql present.