### PR TITLE
Remove some unused plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,11 +52,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>pipeline-utility-steps</artifactId>
-      <version>2.2.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
       <version>6.7</version>
     </dependency>
@@ -107,11 +102,6 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>pipeline-build-step</artifactId>
-      <version>2.7</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-graph-analysis</artifactId>
       <version>1.9</version>
     </dependency>
@@ -119,11 +109,6 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>pipeline-input-step</artifactId>
       <version>2.9</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jenkins-ci.plugins</groupId>
-      <artifactId>pipeline-milestone-step</artifactId>
-      <version>1.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkinsci.plugins</groupId>
@@ -231,6 +216,7 @@
       <version>1.50</version>
     </dependency>
     <!-- not sure if this makes any difference but attempting to fix enforcer errors-->
+    <!-- TODO rather use dependencyManagement if necessary -->
     <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>


### PR DESCRIPTION
Trimming some fat from the image as a follow-up to #14.

The `build` and `milestone` steps have no conceivable function in `jenkinsfile-runner`, so there is no reason to bloat the image with them.

Most of the various steps in `pipeline-utility-steps` _could_ be used in this mode, but nothing in JX build packs actually does, so there is no reason to include it speculatively. With the exception of `tee`, the ones which _could_ work could also just be replaced by a more comprehensive build script as suggested in https://github.com/jenkins-x/draft-packs/issues/83. For example, the raison d’être of the `zip` step is to simplify interoperability on Windows agents, which is irrelevant for JX.

There are a bunch more plugins which are either unused by JX/Prow/buildpacks (`workflow-cps-global-lib`, `docker-workflow`, `docker-commons`, `git`, `git-client`) or not even usable in principle (`pipeline-input-step`, `junit`), but cannot be removed from the image because they are transitive dependencies of plugins we _do_ need, notably `pipeline-model-definition` (a.k.a. “Declarative Pipeline”) which has a fat dependency tree that has not yet been factored out much (CC @abayer).

Testing is via

```sh
make && \
docker build -t jfr -f Dockerfile.filerunner . && \
docker run --rm -v /tmp/Jenkinsfile:/workspace/Jenkinsfile jfr
```

against

```groovy
pipeline {
    agent any
    stages {
        stage('all') {
            steps {
                sh 'cat Jenkinsfile'
            }
        }
    }
}
```

and ignoring the numerous stack traces about `java.net.UnknownHostException: kubernetes.default.svc`.