### PR TITLE
fix: remove chrome browser from base image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -25,12 +25,6 @@ RUN apt-get update && apt-get install -y openjdk-8-jre
 # postgresql-client
 RUN apt-get install -y postgresql-client
 
-# chrome
-RUN apt-get install -y libappindicator1 fonts-liberation libasound2 libnspr4 libnss3 libxss1 lsb-release xdg-utils libappindicator3-1 && \
-    wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
-    dpkg -i google-chrome*.deb && \
-    rm google-chrome*.deb
-
 # USER jenkins
 WORKDIR /home/jenkins
 


### PR DESCRIPTION
The `jx install` does not require anymore chrome to get the API token. Let's remove it from the base image
to reduce the size of the builder image and avoid possible security issues. 

Should we add it to the `javascript` builder in case the user wants to run browser based tests?