### PR TITLE
Linking to jenkins-x-serverless-filerunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # jenkins-x-serverless
 
-A monorepo to build all of the Jenkins-X serverless build images for Prow
+Defines the Jenkins-X [serverless](https://jenkins-x.io/architecture/cloud-native-jenkins/) build images for Prow.
+
+Depends on a base image produced by [jenkins-x-serverless-filerunner](https://github.com/jenkins-x/jenkins-x-serverless-filerunner).


### PR DESCRIPTION
Follows up https://github.com/jenkins-x/jenkins-x-serverless/pull/299 by @garethjevans, which left me baffled as to where the config went! I had to do a full-text search of GitHub to find it.

I also removed the “monorepo” phrasing which seems inappropriate when a large chunk of this repo was just moved to another repo. :-)