### PR TITLE
The entrypoint is the JFR, so it's not expecting this CMD

### DIFF
--- a/Dockerfile.gradle
+++ b/Dockerfile.gradle
@@ -1,7 +1,5 @@
 FROM jenkinsxio/jenkins-filerunner:0.1.20
 
-CMD ["gradle"]
-
 ENV GRADLE_HOME /opt/gradle
 ENV GRADLE_VERSION 4.6
 

--- a/Dockerfile.python
+++ b/Dockerfile.python
@@ -3,8 +3,6 @@ FROM jenkinsxio/jenkins-filerunner:0.1.20
 RUN apt-get update && apt-get -y upgrade
 #RUN yum install -y python36u python36u-libs python36u-devel python36u-pip
 
-CMD ["python3", "--version"]
-
 # jx
 ENV JX_VERSION 1.3.1014
 RUN curl -Lf https://github.com/jenkins-x/jx/releases/download/v${JX_VERSION}/jx-linux-amd64.tar.gz | tar xzv && \


### PR DESCRIPTION
The base image for the JenkinsfileRunner container has defined [an entrypoint to run the JFR](https://github.com/jenkins-x/jenkins-x-serverless-filerunner/blob/486226e2d7d05b7d4ad983f5591bb2e760dd9c77/Dockerfile#L23-L26). This is not compatible with having a `CMD` defined as `gradle`, and it makes newly created gradle applications to fail. You can reproduce the error by using `jx create quickstart` and selecting the gradle spring boot quickstart.

I saw that the Python image has the same problem, so I removed the `CMD` from there as well.